### PR TITLE
Broadcast flag for the BusHandler socket

### DIFF
--- a/pyhausbus/BusHandler.py
+++ b/pyhausbus/BusHandler.py
@@ -33,6 +33,7 @@ class BusHandler:
   def __init__(self):
     if BusHandler._singleInstance is None:
       self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+      self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
       x = UdpReceiveWorker(self.busDataReceived)
       x.startWorker()
       self._getBroadcastIp()

--- a/pyhausbus/IBusDataListener.py
+++ b/pyhausbus/IBusDataListener.py
@@ -3,5 +3,5 @@ from abc import ABC, abstractmethod
 class IBusDataListener(ABC):
 
     @abstractmethod
-    def busDataReceived(self,BusDataMessage):
-        pass 
+    def busDataReceived(self,busDataMessage):
+        pass

--- a/pyhausbus/de/hausbus/homeassistant/proxy/controller/params/EFirmwareId.py
+++ b/pyhausbus/de/hausbus/homeassistant/proxy/controller/params/EFirmwareId.py
@@ -23,7 +23,7 @@ class EFirmwareId(Enum):
 
     return EFirmwareId.SER_UNKNOWN
   def getTemplateId(self) -> str:
-    if (self.name.startsWith("HB")):
+    if (self.name.startswith("HB")):
         return "HBC"
     return self.name
 


### PR DESCRIPTION
Had to include the broadcast flag for the socket, to be able to send broadcast messages on a UNIX system.

"If the socket protocol supports broadcast and the specified address is a broadcast address for the socket protocol, sendto() shall fail if the SO_BROADCAST option is not set for the socket."

See https://pubs.opengroup.org/onlinepubs/009695399/functions/sendto.html